### PR TITLE
Add Playwright test for EPAM navigation

### DIFF
--- a/tests/navigate-to-epam.spec.ts
+++ b/tests/navigate-to-epam.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Navigate to EPAM and verify Client Work', async ({ page }) => {
+  // 1) Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // 2) Select "Services" from the header menu.
+  await page.click('header >> text=Services');
+
+  // 3) Click the "Explore Our Client Work" link.
+  await page.click('text=Explore Our Client Work');
+
+  // 4) Verify that the "Client Work" text is visible on the page.
+  const clientWorkText = await page.isVisible('text=Client Work');
+  expect(clientWorkText).toBeTruthy();
+});


### PR DESCRIPTION
This PR adds a Playwright test script to navigate to the EPAM website, select "Services" from the header menu, click on the "Explore Our Client Work" link, and verify that the "Client Work" text is visible on the page.