### PR TITLE
Add Playwright test for Client Work page

### DIFF
--- a/tests/epam-client-work.spec.ts
+++ b/tests/epam-client-work.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify Client Work page', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Step 2: Select "Services" from the header menu
+  await page.click('header >> text=Services');
+
+  // Step 3: Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This PR adds a Playwright test to verify the navigation and visibility of the 'Client Work' page on the EPAM website. The test includes the following steps:\n\n1. Navigate to https://www.epam.com/\n2. Select 'Services' from the header menu.\n3. Click the 'Explore Our Client Work' link.\n4. Verify that the 'Client Work' text is visible on the page.